### PR TITLE
Increase AppleScript timeout

### DIFF
--- a/lib/photoshop-eval.js
+++ b/lib/photoshop-eval.js
@@ -58,7 +58,9 @@ function evalInPhotoshop(fn, args){
     var cliArgs = []
     
     cliArgs.push("-e", 'on run argv')
+    cliArgs.push("-e", 'with timeout of 600 seconds')
     cliArgs.push("-e",   'tell application "' + evalInPhotoshop.getName() + '" to do javascript (item 1 of argv)' + (module.exports.debugger ? ' show debugger on runtime error' : ''))
+    cliArgs.push("-e", 'end timeout')
     cliArgs.push("-e", 'end run')
     
     cliArgs.push(script)


### PR DESCRIPTION
I am running a big script that is hitting the 2 min default time limit. Bumped time limit up to 10 minutes.