### PR TITLE
Support new versions of Photoshop CC

### DIFF
--- a/lib/photoshop-eval.js
+++ b/lib/photoshop-eval.js
@@ -24,11 +24,13 @@ evalInPhotoshop.getName = function(){
     try {
       ;(function(error, Applications){
 
-        evalInPhotoshop.NAME = Applications.find(function(value){
-         return value.indexOf('Adobe Photoshop CC') != -1 ||
-             value == 'Adobe Photoshop CS6' ||
-             value == 'Adobe Photoshop CS5';
-        });
+        for(var i = 0; i < Applications.length; i++) {
+          var value = Applications[i];
+          if(value.indexOf('Adobe Photoshop CC') != -1 || value == 'Adobe Photoshop CS6' || value == 'Adobe Photoshop CS5') {
+            evalInPhotoshop.NAME = value;
+            break;
+          }
+        }
 
       }(null, require('fs').readdirSync('/Applications')));
     } catch(e){}

--- a/lib/photoshop-eval.js
+++ b/lib/photoshop-eval.js
@@ -23,11 +23,13 @@ evalInPhotoshop.getName = function(){
   if (evalInPhotoshop.NAME == null) {
     try {
       ;(function(error, Applications){
-        if (Applications.indexOf('Adobe Photoshop CC 2015') != -1) evalInPhotoshop.NAME = "Adobe Photoshop CC 2015";
-        else if (Applications.indexOf('Adobe Photoshop CC 2014') != -1) evalInPhotoshop.NAME = "Adobe Photoshop CC 2014";
-        else if (Applications.indexOf('Adobe Photoshop CC') != -1) evalInPhotoshop.NAME = "Adobe Photoshop CC";
-        else if (Applications.indexOf('Adobe Photoshop CS6') != -1) evalInPhotoshop.NAME = "Adobe Photoshop CS6";
-        else if (Applications.indexOf('Adobe Photoshop CS5') != -1) evalInPhotoshop.NAME = "Adobe Photoshop CS5";
+
+        evalInPhotoshop.NAME = Applications.find(function(value){
+         return value.indexOf('Adobe Photoshop CC') != -1 ||
+             value == 'Adobe Photoshop CS6' ||
+             value == 'Adobe Photoshop CS5';
+        });
+
       }(null, require('fs').readdirSync('/Applications')));
     } catch(e){}
   }


### PR DESCRIPTION
The latest version of Photoshop (```Adobe Photoshop CC 2015.5```) is currently not supported. These changes will support all current and future versions of Photoshop CC so the code will not need to be continually updated.